### PR TITLE
Bump eslint-config-mammoth to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-source": "^2.18.0",
     "ember-try": "^0.2.23",
     "eslint": "^3.18.0",
-    "eslint-config-mammoth": "0.1.0",
+    "eslint-config-mammoth": "v0.2.0",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },


### PR DESCRIPTION
This will bump the eslint-config-mammoth dependency to version v0.2.0


- [ ] Run `yarn install` and commit changes yarn.lock